### PR TITLE
package.json: fix main reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pluggable.js",
   "version": "2.0.0",
   "description": "Lets you make your JS code pluggable while still keeping sensitive objects and data private through closures.",
-  "main": "pluggable.js",
+  "main": "dist/pluggable.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
'main' contains the name of the file to load when a module required by the package name. Current value 'pluggable.js' points to nowhere - there is no 'pluggable.js' in the package root. Point 'main' to 'dist/pluggable.js' instead so that when 'pluggable.js' is required with no specific path 'dist/pluggable.js' is required instead.